### PR TITLE
fix: added loading state to prevent duplicate form submissions

### DIFF
--- a/src/app/register/_components/RegisterForm.tsx
+++ b/src/app/register/_components/RegisterForm.tsx
@@ -8,13 +8,14 @@ import {
 import { trpc } from "@/utils/trpc";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 
 export default function RegisterForm(props: { email: string }) {
 	const router = useRouter();
 	const userRegistration = trpc.user.register.useMutation();
+	const [loading, setLoading] = useState(false); // New loading state
 	const {
 		register,
 		handleSubmit,
@@ -25,14 +26,17 @@ export default function RegisterForm(props: { email: string }) {
 	});
 
 	const onSubmit: SubmitHandler<RegisterFormSchemaType> = (values) => {
-		const loading = toast.loading("Registering user");
+		setLoading(true);
+		const toastId = toast.loading("Registering user...");
 		userRegistration.mutate(values, {
 			onSuccess: (val) => {
-				toast.success("User registered successfully", { id: loading });
+				setLoading(false);
+				toast.success("User registered successfully", { id: toastId });
 				router.push("/student/home");
 			},
 			onError: (err) => {
-				toast.error(err.message, { id: loading });
+				setLoading(false);
+				toast.error(err.message, { id: toastId });
 			},
 		});
 	};
@@ -48,10 +52,10 @@ export default function RegisterForm(props: { email: string }) {
 			onSubmit={handleSubmit(onSubmit)}
 			className="flex flex-col border p-5 w-full"
 		>
-			<span className=" font-medium text-2xl text-center">Register</span>
+			<span className="font-medium text-2xl text-center">Register</span>
 			<label className="mt-2">Name</label>
 			<input type="text" className="border px-2 py-1" {...register("name")} />
-			<span className=" text-red-500 text-sm">{errors.name?.message}</span>
+			<span className="text-red-500 text-sm">{errors.name?.message}</span>
 			<label className="mt-2">Email</label>
 			<input
 				defaultValue={props.email}
@@ -60,7 +64,7 @@ export default function RegisterForm(props: { email: string }) {
 				{...register("email")}
 				disabled
 			/>
-			<span className=" text-red-500 text-sm">{errors.email?.message}</span>
+			<span className="text-red-500 text-sm">{errors.email?.message}</span>
 			<label className="mt-2">College</label>
 			<input
 				{...(defaultValues(props.email) !== undefined && {
@@ -71,7 +75,7 @@ export default function RegisterForm(props: { email: string }) {
 				{...register("college")}
 				disabled={defaultValues(props.email) !== undefined}
 			/>
-			<span className=" text-red-500 text-sm">{errors.college?.message}</span>
+			<span className="text-red-500 text-sm">{errors.college?.message}</span>
 			<label className="mt-2">Unique Identification No./ID</label>
 			<input
 				defaultValue={defaultValues(props.email)?.uid}
@@ -80,12 +84,15 @@ export default function RegisterForm(props: { email: string }) {
 				{...register("uid")}
 				disabled={defaultValues(props.email) !== undefined}
 			/>
-			<span className=" text-red-500 text-sm">{errors.uid?.message}</span>
+			<span className="text-red-500 text-sm">{errors.uid?.message}</span>
 			<button
 				type="submit"
-				className="mt-5 border mx-auto px-2 py-1 bg-slate-200"
+				className={`mt-5 border mx-auto px-2 py-1 ${
+					loading ? "bg-gray-400 cursor-not-allowed" : "bg-slate-200"
+				}`}
+				disabled={loading}
 			>
-				Submit
+				{loading ? "Loading..." : "Submit"}
 			</button>
 		</form>
 	);


### PR DESCRIPTION
Fix: Prevent Duplicate Registrations by Adding a Loading State to Register Button

Overview: This PR fixes an issue where users could click the Register button multiple times, causing duplicate API requests and duplicate entries in the database.

Changes Made: 
Added a loading state to the RegisterForm component.
Disabled the Submit button when an API request is in progress.
Updated the button text to "Loading..." while processing.
Ensured the button is re-enabled after the API request is completed (success or failure).

How This Fix Works: 
When the user clicks "Submit," the button is disabled immediately, preventing further clicks.
The form submission proceeds, and a loading toast is shown.
On success, the user is redirected to the student dashboard.
On error, an error message is displayed, and the button is re-enabled for retrying.

Fixes #3 