### PR TITLE
Add end-to-end tests for professor login

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
 			"cypress/e2e/landing.cy.ts",
 			"cypress/e2e/home.cy.ts",
 			"cypress/e2e/api/*.cy.ts",
+			"cypress/e2e/professorLogin.cy.ts",
 		],
 	},
 });

--- a/cypress/e2e/professorLogin.cy.ts
+++ b/cypress/e2e/professorLogin.cy.ts
@@ -1,0 +1,33 @@
+describe("Professor Login", () => {
+	beforeEach(() => {
+		cy.exec("pnpm db:seed");
+	});
+
+	afterEach(() => {
+		cy.exec("pnpm db:reset");
+	});
+
+	it("should successfully login with valid credentials", () => {
+		cy.visit("/professor/login");
+		cy.get("input[name=email]").type("professor@example.com");
+		cy.get("input[name=password]").type("validpassword");
+		cy.contains("Submit").click();
+		cy.url().should("include", "/professor/home");
+	});
+
+	it("should show error for invalid email", () => {
+		cy.visit("/professor/login");
+		cy.get("input[name=email]").type("invalid@example.com");
+		cy.get("input[name=password]").type("validpassword");
+		cy.contains("Submit").click();
+		cy.contains("User not found").should("exist");
+	});
+
+	it("should show error for invalid password", () => {
+		cy.visit("/professor/login");
+		cy.get("input[name=email]").type("professor@example.com");
+		cy.get("input[name=password]").type("invalidpassword");
+		cy.contains("Submit").click();
+		cy.contains("Invalid password").should("exist");
+	});
+});


### PR DESCRIPTION
Add end-to-end tests for professor login using Cypress.

* Add `cypress/e2e/professorLogin.cy.ts` with tests for professor login
  - Include tests for successful login, invalid email, and invalid password scenarios
* Update `cypress.config.ts` to include the new spec pattern for professor login tests

