### PR TITLE
Add Attendance Schema and API to Track Daily Attendance

### DIFF
--- a/drizzle/migrations/0002_overconfident_whiplash.sql
+++ b/drizzle/migrations/0002_overconfident_whiplash.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS "attendance" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"class_id" integer NOT NULL,
+	"date" date NOT NULL,
+	"status" boolean NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "attendance" ADD CONSTRAINT "attendance_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "attendance" ADD CONSTRAINT "attendance_class_id_classes_id_fk" FOREIGN KEY ("class_id") REFERENCES "public"."classes"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/drizzle/migrations/meta/0002_snapshot.json
+++ b/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,285 @@
+{
+	"id": "ad6b5ae4-05de-4b6c-9a8e-9f576acfb0a5",
+	"prevId": "a0ad6733-8a99-4e7b-90b4-b83d548f4883",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.attendance": {
+			"name": "attendance",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date": {
+					"name": "date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"attendance_user_id_users_id_fk": {
+					"name": "attendance_user_id_users_id_fk",
+					"tableFrom": "attendance",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"attendance_class_id_classes_id_fk": {
+					"name": "attendance_class_id_classes_id_fk",
+					"tableFrom": "attendance",
+					"tableTo": "classes",
+					"columnsFrom": ["class_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.classes": {
+			"name": "classes",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(75)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"professor_id": {
+					"name": "professor_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.colleges": {
+			"name": "colleges",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(75)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.departments": {
+			"name": "departments",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		},
+		"public.professors": {
+			"name": "professors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"password": {
+					"name": "password",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"department_id": {
+					"name": "department_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"college_id": {
+					"name": "college_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"professors_email_unique": {
+					"name": "professors_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			}
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uid": {
+					"name": "uid",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"college_id": {
+					"name": "college_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			}
+		},
+		"public.users_to_classes": {
+			"name": "users_to_classes",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"users_to_classes_user_id_users_id_fk": {
+					"name": "users_to_classes_user_id_users_id_fk",
+					"tableFrom": "users_to_classes",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"users_to_classes_class_id_classes_id_fk": {
+					"name": "users_to_classes_class_id_classes_id_fk",
+					"tableFrom": "users_to_classes",
+					"tableTo": "classes",
+					"columnsFrom": ["class_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {}
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
 			"when": 1736925077985,
 			"tag": "0001_amusing_nuke",
 			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1738670747787,
+			"tag": "0002_overconfident_whiplash",
+			"breakpoints": true
 		}
 	]
 }

--- a/drizzle/schema/attendance.ts
+++ b/drizzle/schema/attendance.ts
@@ -1,0 +1,27 @@
+import { boolean, date, integer, pgTable, serial } from "drizzle-orm/pg-core";
+import { relations } from "drizzle-orm";
+import { users } from "./users";
+import { classes } from "./classes";
+
+export const attendance = pgTable("attendance", {
+	id: serial("id").primaryKey(),
+	userId: integer("user_id")
+		.notNull()
+		.references(() => users.id, { onDelete: "cascade" }),
+	classId: integer("class_id")
+		.notNull()
+		.references(() => classes.id, { onDelete: "cascade" }),
+	date: date("date").notNull(),
+	status: boolean("status").notNull(), // true = present, false = absent
+});
+
+export const attendanceRelations = relations(attendance, ({ one }) => ({
+	student: one(users, {
+		fields: [attendance.userId],
+		references: [users.id],
+	}),
+	class: one(classes, {
+		fields: [attendance.classId],
+		references: [classes.id],
+	}),
+}));

--- a/src/app/api/attendance/route.ts
+++ b/src/app/api/attendance/route.ts
@@ -1,0 +1,27 @@
+import { attendance } from "../../../../drizzle/schema/attendance";
+import { type NextRequest, NextResponse } from "next/server";
+import { db } from "../../../../drizzle/index";
+
+export async function POST(req: NextRequest) {
+	const { userId, classId, date, status } = await req.json();
+	console.log("userId", userId);
+	console.log("classId", classId);
+	console.log("date", date);
+	console.log("status", status);
+
+	if (!userId || !classId || !date) {
+		return NextResponse.json(
+			{ error: "Missing required fields" },
+			{ status: 400 },
+		);
+	}
+
+	await db.insert(attendance).values({
+		userId,
+		classId,
+		date: new Date(date).toISOString().split("T")[0],
+		status,
+	});
+
+	return NextResponse.json({ message: "Attendance marked successfully" });
+}


### PR DESCRIPTION
- Created a new `attendance` schema to track student attendance for each class on a given day.  
- Added fields to the schema: `userId`, `classId`, `date`, and `status` (present/absent).  
- Implemented API to allow professors to mark attendance via `POST` request.  
- Ensured relational integrity between users, classes, and attendance records.  

**Changes:**  
- **New Schema:** `attendance` table with foreign keys to `users` and `classes`.  
- **API Endpoint:** `/api/attendance` to insert attendance records.  
---

closes #6 